### PR TITLE
[WIP]カスタムタグ登録フォームからエモーティコンリストを出せるようにした

### DIFF
--- a/script.js
+++ b/script.js
@@ -98,6 +98,7 @@
         var imageUrlInput = document.createElement('input');
         var imageUrlLabel = document.createElement('div');
         var submit = document.createElement('input');
+        var selector = document.createElement('div');
         var close = document.createElement('input');
         var triangle = document.createElement('div');
         var form = document.createElement('form');
@@ -128,6 +129,53 @@
         submit.setAttribute('class', 'customButtonFormSubmit');
         submit.setAttribute('type', 'submit');
         submit.setAttribute('value', 'Add');
+        selector.setAttribute('class', 'customButtonFormSelector icoFontEmoticon icoSizeLarge');
+        selector.setAttribute('value', '');
+        selector.addEventListener('click', function(){
+            var emoticonSelector = document.getElementById('emoticonListCustomSelector');
+            if(!!emoticonSelector){
+                // エモーティコンリストボックスがすでに存在する場合は閉じる
+                emoticonSelector.parentNode.removeChild(emoticonSelector);
+                return;
+            }
+
+            // エモーティコンのリストボックスの親要素をCloneする
+            var emoticonList = document.getElementById('_emoticonList').cloneNode(false);
+            emoticonList.id = 'emoticonListCustomSelector';
+            emoticonList.classList.add('toolTip');
+            emoticonList.classList.add('toolTipWhite');
+            emoticonList.classList.add('mainContetTooltip');
+            emoticonList.setAttribute('style', 'display: block;');
+
+            // エモーティコンのリストボックスをCloneする
+            var emoticonGallery = document.getElementById('_emoticonGallery').cloneNode(true);
+            emoticonGallery.id = 'emoticonGalleryCustomSelector';
+
+            emoticonList.appendChild(emoticonGallery);
+
+            // エモーティコンをクリックした際の動作
+            var emoticonListObject = emoticonList.querySelectorAll('li');
+            Array.prototype.forEach.call(emoticonListObject, function(el, index) {
+                el.addEventListener('click', function() {
+                    // エモーティコンの情報をカスタムタグ入力フォームに埋め込む
+                    var url = el.getElementsByTagName('img')[0].src;
+                    var tag = el.getElementsByTagName('img')[0].alt;
+                    nameInput.value = tag;
+                    openingTagInput.value = tag;
+                    imageUrlInput.value = url;
+
+                    // エモーティコンリストを閉じる
+                    document.body.removeChild(document.getElementById('emoticonListCustomSelector'));
+                });
+            });
+            document.body.appendChild(emoticonList);
+
+            // エモーティコンのボックスの位置調節
+            var emoticonListTop = form.getBoundingClientRect().top - 193;
+            var emoticonListLeft = addCustomButton.getBoundingClientRect().left + (addCustomButton.clientWidth / 2) - (emoticonList.clientWidth / 2);
+            emoticonList.style.top = emoticonListTop + 'px';
+            emoticonList.style.left = emoticonListLeft + 'px';
+        });
         close.setAttribute('class', 'customButtonFormClose');
         close.setAttribute('type', 'button');
         close.setAttribute('value', 'x');
@@ -175,6 +223,7 @@
         form.appendChild(imageUrlLabel);
         form.appendChild(imageUrlInput);
         form.appendChild(submit);
+        form.appendChild(selector);
         form.appendChild(close);
         form.appendChild(triangle);
         document.body.appendChild(form);

--- a/script.js
+++ b/script.js
@@ -11,25 +11,35 @@
     var chatSendTool = document.getElementById('_chatSendTool');
 
     // ボタンクラス
-    var Button = function(id, name, description, openingTag, closingTag){
+    var Button = function(id, name, description, openingTag, closingTag, imageUrl){
         this.id = id;
         this.name = name || '';
         this.description = description || '';
         this.openingTag = openingTag || '';
         this.closingTag = closingTag || '';
+        this.imageUrl = imageUrl || '';
         this.textClassName = 'buttonText';
+        this.emoticonClassName = 'buttonEmoticon';
         this.triggerClassName = 'buttonTrigger';
     };
     Button.prototype.chatText = document.getElementById('_chatText');
     Button.prototype.createElement = function(){
         var self = this;
         var textNode = document.createTextNode(this.name);
-        var span = document.createElement('span');
         var div = document.createElement('div');
         var li = document.createElement('li');
-        span.appendChild(textNode);
-        span.setAttribute('class', this.textClassName);
-        div.appendChild(span);
+        if (this.imageUrl !== '') {
+            // 絵文字ボタンの場合
+            var img = document.createElement('img');
+            img.setAttribute('class', this.emoticonClassName);
+            img.setAttribute('src', this.imageUrl);
+            div.appendChild(img);
+        } else {
+            var span = document.createElement('span');
+            span.appendChild(textNode);
+            span.setAttribute('class', this.textClassName);
+            div.appendChild(span);
+        }
         div.setAttribute('class', this.triggerClassName);
         div.addEventListener('click', function(){
             self.chatText.focus();
@@ -85,6 +95,8 @@
         var openingTagLabel = document.createElement('div');
         var closingTagInput = document.createElement('input');
         var closingTagLabel = document.createElement('div');
+        var imageUrlInput = document.createElement('input');
+        var imageUrlLabel = document.createElement('div');
         var submit = document.createElement('input');
         var close = document.createElement('input');
         var triangle = document.createElement('div');
@@ -109,6 +121,10 @@
         closingTagInput.setAttribute('type', 'text');
         closingTagLabel.appendChild(document.createTextNode('Closing Tag'));
         closingTagLabel.setAttribute('class', 'customButtonFormClosingTagLabel');
+        imageUrlInput.setAttribute('class', 'customButtonFormImageUrlInput');
+        imageUrlInput.setAttribute('type', 'text');
+        imageUrlLabel.appendChild(document.createTextNode('Image URL'));
+        imageUrlLabel.setAttribute('class', 'customButtonFormImageUrlLabel');
         submit.setAttribute('class', 'customButtonFormSubmit');
         submit.setAttribute('type', 'submit');
         submit.setAttribute('value', 'Add');
@@ -132,15 +148,17 @@
             var description = descriptionInput.value;
             var openingTag = openingTagInput.value;
             var closingTag = closingTagInput.value;
+            var imageUrl = imageUrlInput.value;
             data[id] = {
                 name: name,
                 description: description,
                 openingTag: openingTag,
                 closingTag: closingTag,
+                imageUrl: imageUrl,
             };
             chrome.storage.local.set(data, function(){
                 var chatSendToolExtension = document.getElementById('_chatSendToolExtension');
-                var customButton = new CustomButton(id, name, description, openingTag, closingTag);
+                var customButton = new CustomButton(id, name, description, openingTag, closingTag, imageUrl);
                 chatSendToolExtension.insertBefore(customButton.createElement(), document.getElementById('_addCustomButton'));
                 form.parentNode.removeChild(form);
             });
@@ -154,6 +172,8 @@
         form.appendChild(openingTagInput);
         form.appendChild(closingTagLabel);
         form.appendChild(closingTagInput);
+        form.appendChild(imageUrlLabel);
+        form.appendChild(imageUrlInput);
         form.appendChild(submit);
         form.appendChild(close);
         form.appendChild(triangle);
@@ -196,38 +216,43 @@
         'description': 'info：選択したメッセージをinfoタグで囲みます',
         'openingTag': '[info]',
         'closingTag': '[/info]',
+        'imageUrl': '',
     }, {
         'name': 'title',
         'description': 'title：選択したメッセージをtitleタグで囲みます',
         'openingTag': '[title]',
         'closingTag': '[/title]',
+        'imageUrl': '',
     }, {
         'name': 'code',
         'description': 'code：選択したメッセージをcodeタグで囲みます',
         'openingTag': '[code]',
         'closingTag': '[/code]',
+        'imageUrl': '',
     }, {
         'name': 'bow',
         'description': 'bow：メッセージにおじぎエモーティコンを挿入します',
         'openingTag': '(bow)',
         'closingTag': '',
+        'imageUrl': '',
     }, {
         'name': 'roger',
         'description': 'roger：メッセージに了解！エモーティコンを挿入します',
         'openingTag': '(roger)',
         'closingTag': '',
+        'imageUrl': '',
     }];
 
     // ボタンを作成
     buttonParams.forEach(function(param, index){
-        var button = new Button(index, param.name, param.description, param.openingTag, param.closingTag);
+        var button = new Button(index, param.name, param.description, param.openingTag, param.closingTag, param.imageUrl);
         chatSendToolExtension.insertBefore(button.createElement(), addCustomButton);
     });
 
     // カスタムボタンを作成
     var customButtons = chrome.storage.local.get(function(result){
         Object.keys(result).forEach(function(id){
-            var b = new CustomButton(id, result[id].name, result[id].description, result[id].openingTag, result[id].closingTag);
+            var b = new CustomButton(id, result[id].name, result[id].description, result[id].openingTag, result[id].closingTag, result[id].imageUrl);
             chatSendToolExtension.insertBefore(b.createElement(), addCustomButton);
         });
     });

--- a/style.css
+++ b/style.css
@@ -53,6 +53,20 @@
     top: 1px;
     -webkit-user-select: none;
 }
+.chatSendToolExtension .buttonEmoticon{
+    border: none;
+    color: #000000;
+    display: inline-block;
+    font-size: 12px;
+    height: 20px;
+    width: 20px;
+    line-height: 16px;
+    margin: 0;
+    padding: 0 4px;
+    position: relative;
+    text-align: center;
+    top: 1px;
+}
 .chatSendToolExtension .addButtonText{
     background-color: #ffffff;
     border: none;
@@ -72,7 +86,7 @@
     border-radius: 4px;
     color: #ffffff;
     display: block;
-    height: 145px;
+    height: 168px;
     position: fixed;
     top: 320px;
     width: 250px;
@@ -155,6 +169,24 @@
     top: 97px;
     width: 159px;
 }
+.customButtonForm .customButtonFormImageUrlLabel{
+    font-size: 12px;
+    left: 5px;
+    line-height: 18px;
+    position: absolute;
+    top: 120px;
+}
+.customButtonForm .customButtonFormImageUrlInput{
+    border: none;
+    display: block;
+    font-size: 12px;
+    left: 80px;
+    line-height: 16px;
+    padding: 0 3px;
+    position: absolute;
+    top: 120px;
+    width: 159px;
+}
 .customButtonForm .customButtonFormClose{
     background-color: #444444;
     border: none;
@@ -173,7 +205,7 @@
     left: 211px;
     line-height: 18px;
     position: absolute;
-    top: 120px;
+    top: 143px;
 }
 .customButtonForm .customButtonFormTriangle{
     border-color: #444444 transparent transparent transparent;

--- a/style.css
+++ b/style.css
@@ -207,6 +207,16 @@
     position: absolute;
     top: 143px;
 }
+.customButtonForm .customButtonFormSelector{
+    background-color: #444444;
+    border: none;
+    color: #ffffff;
+    font-size: 18px;
+    left: 10px;
+    line-height: 18px;
+    position: absolute;
+    top: 143px;
+}
 .customButtonForm .customButtonFormTriangle{
     border-color: #444444 transparent transparent transparent;
     border-style: solid;
@@ -216,4 +226,18 @@
     left: 118px;
     position: absolute;
     width: 0;
+}
+#emoticonListCustomSelector {
+    z-index: 1002;
+    display: block;
+    width: 259px;
+    position: absolute;
+    top: 228px;
+    left: 216.219px;
+}
+#emoticonGalleryCustomSelector {
+    opacity: 1;
+    z-index: 1002;
+    display: block;
+    position: relative;
 }


### PR DESCRIPTION
さきにこっちのレビューおね　#9

## 概要

カスタムタグ登録（#9）で毎回画像URLを入力するのめんどかったので、エモーティコンリストを表示させ、そこで選択すれば登録フォームに自動入力されるようにした。

## スクリーンショット

登録フォームにエモーティコンリスト表示のためのボタンを追加

![image](https://cloud.githubusercontent.com/assets/9024344/11456425/e7f8cf2e-96cb-11e5-915e-765955ad6ec0.png)

左下のボタンをクリックするとエモーティコンリストが表示される

![image](https://cloud.githubusercontent.com/assets/9024344/11456429/fa2c4356-96cb-11e5-8307-61475cdb32dd.png)

汗エモーティコンを選択すると登録フォームに名称、テキスト、画像URLが自動入力される

![image](https://cloud.githubusercontent.com/assets/9024344/11456435/0a9b9d5e-96cc-11e5-9ec2-b1752a4e508f.png)

Addを押すと追加された

![image](https://cloud.githubusercontent.com/assets/9024344/11456436/366e7c1c-96cc-11e5-831e-0219d8a7cd9c.png)